### PR TITLE
Improve mobile responsiveness of top bar

### DIFF
--- a/src/components/common/FeedbackDialog.tsx
+++ b/src/components/common/FeedbackDialog.tsx
@@ -89,6 +89,8 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
         sx: {
           backgroundColor: 'background.paper',
           boxShadow: 'none',
+          margin: { xs: 1, sm: 2 },
+          maxHeight: { xs: '95vh', sm: '90vh' },
         },
       }}
       slotProps={{
@@ -101,16 +103,25 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
     >
       <TerminalBox title="SUBMIT FEEDBACK" variant="heavy">
         {success ? (
-          <Box sx={{ textAlign: 'center', py: 3 }}>
+          <Box sx={{ textAlign: 'center', py: { xs: 2, sm: 3 } }}>
             <Typography
               variant="h6"
-              sx={{ color: 'success.main', fontFamily: 'monospace', mb: 1 }}
+              sx={{
+                color: 'success.main',
+                fontFamily: 'monospace',
+                mb: 1,
+                fontSize: { xs: '1rem', sm: '1.15rem', md: '1.25rem' },
+              }}
             >
               ✓ FEEDBACK SUBMITTED
             </Typography>
             <Typography
               variant="body2"
-              sx={{ color: 'text.secondary', fontFamily: 'monospace' }}
+              sx={{
+                color: 'text.secondary',
+                fontFamily: 'monospace',
+                fontSize: { xs: '0.75rem', sm: '0.85rem' },
+              }}
             >
               Thank you! Your feedback has been recorded as a GitHub issue.
             </Typography>
@@ -119,39 +130,54 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
           <>
             <Typography
               variant="body2"
-              sx={{ color: 'text.secondary', mb: 2, fontFamily: 'monospace' }}
+              sx={{
+                color: 'text.secondary',
+                mb: { xs: 1.5, sm: 2 },
+                fontFamily: 'monospace',
+                fontSize: { xs: '0.75rem', sm: '0.85rem' },
+              }}
             >
               &gt; Report bugs, request features, or share feedback
             </Typography>
 
             {error && (
-              <Alert severity="error" sx={{ mb: 2, fontFamily: 'monospace' }}>
+              <Alert
+                severity="error"
+                sx={{
+                  mb: { xs: 1.5, sm: 2 },
+                  fontFamily: 'monospace',
+                  fontSize: { xs: '0.75rem', sm: '0.85rem' },
+                }}
+              >
                 {error}
               </Alert>
             )}
 
-            <Stack spacing={2}>
+            <Stack spacing={{ xs: 1.5, sm: 2 }}>
               <FormControl fullWidth>
-                <InputLabel>Category</InputLabel>
+                <InputLabel sx={{ fontSize: { xs: '0.85rem', sm: '1rem' } }}>Category</InputLabel>
                 <Select
                   value={category}
                   onChange={(e) => setCategory(e.target.value)}
                   label="Category"
-                  sx={{ fontFamily: 'monospace' }}
+                  sx={{
+                    fontFamily: 'monospace',
+                    fontSize: { xs: '0.85rem', sm: '0.95rem' },
+                  }}
                 >
-                  <MenuItem value="bug" sx={{ fontFamily: 'monospace' }}>
+                  <MenuItem value="bug" sx={{ fontFamily: 'monospace', fontSize: { xs: '0.85rem', sm: '0.95rem' } }}>
                     Bug Report
                   </MenuItem>
-                  <MenuItem value="feature" sx={{ fontFamily: 'monospace' }}>
+                  <MenuItem value="feature" sx={{ fontFamily: 'monospace', fontSize: { xs: '0.85rem', sm: '0.95rem' } }}>
                     Feature Request
                   </MenuItem>
-                  <MenuItem value="improvement" sx={{ fontFamily: 'monospace' }}>
+                  <MenuItem value="improvement" sx={{ fontFamily: 'monospace', fontSize: { xs: '0.85rem', sm: '0.95rem' } }}>
                     Improvement
                   </MenuItem>
-                  <MenuItem value="question" sx={{ fontFamily: 'monospace' }}>
+                  <MenuItem value="question" sx={{ fontFamily: 'monospace', fontSize: { xs: '0.85rem', sm: '0.95rem' } }}>
                     Question
                   </MenuItem>
-                  <MenuItem value="other" sx={{ fontFamily: 'monospace' }}>
+                  <MenuItem value="other" sx={{ fontFamily: 'monospace', fontSize: { xs: '0.85rem', sm: '0.95rem' } }}>
                     Other
                   </MenuItem>
                 </Select>
@@ -164,7 +190,15 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
                 fullWidth
                 required
                 placeholder="Brief summary of your feedback"
-                sx={{ '& input': { fontFamily: 'monospace' } }}
+                sx={{
+                  '& input': {
+                    fontFamily: 'monospace',
+                    fontSize: { xs: '0.85rem', sm: '0.95rem' },
+                  },
+                  '& label': {
+                    fontSize: { xs: '0.85rem', sm: '1rem' },
+                  },
+                }}
               />
 
               <TextField
@@ -176,7 +210,15 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
                 multiline
                 rows={4}
                 placeholder="Provide details about your feedback..."
-                sx={{ '& textarea': { fontFamily: 'monospace' } }}
+                sx={{
+                  '& textarea': {
+                    fontFamily: 'monospace',
+                    fontSize: { xs: '0.85rem', sm: '0.95rem' },
+                  },
+                  '& label': {
+                    fontSize: { xs: '0.85rem', sm: '1rem' },
+                  },
+                }}
               />
 
               <TextField
@@ -186,16 +228,28 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
                 fullWidth
                 type="email"
                 placeholder="For follow-up (optional)"
-                sx={{ '& input': { fontFamily: 'monospace' } }}
+                sx={{
+                  '& input': {
+                    fontFamily: 'monospace',
+                    fontSize: { xs: '0.85rem', sm: '0.95rem' },
+                  },
+                  '& label': {
+                    fontSize: { xs: '0.85rem', sm: '1rem' },
+                  },
+                }}
               />
 
               <Divider variant="simple" />
 
-              <Box sx={{ display: 'flex', gap: 2 }}>
+              <Box sx={{ display: 'flex', gap: { xs: 1, sm: 2 } }}>
                 <Button
                   onClick={handleClose}
                   disabled={loading}
-                  sx={{ fontFamily: 'monospace' }}
+                  sx={{
+                    fontFamily: 'monospace',
+                    fontSize: { xs: '0.75rem', sm: '0.85rem', md: '0.9rem' },
+                    minHeight: { xs: '44px', sm: '40px' },
+                  }}
                   fullWidth
                 >
                   CANCEL
@@ -204,7 +258,11 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
                   variant="contained"
                   onClick={handleSubmit}
                   disabled={!isFormValid || loading}
-                  sx={{ fontFamily: 'monospace' }}
+                  sx={{
+                    fontFamily: 'monospace',
+                    fontSize: { xs: '0.75rem', sm: '0.85rem', md: '0.9rem' },
+                    minHeight: { xs: '44px', sm: '40px' },
+                  }}
                   fullWidth
                 >
                   {loading ? (

--- a/src/components/common/SettingsMenu.tsx
+++ b/src/components/common/SettingsMenu.tsx
@@ -28,12 +28,13 @@ export function SettingsMenu() {
         onClick={handleClick}
         sx={{
           color: 'primary.main',
+          padding: { xs: 1, sm: 1, md: 1 },
           '&:hover': {
             backgroundColor: 'rgba(46, 127, 255, 0.1)',
           },
         }}
       >
-        <SettingsIcon />
+        <SettingsIcon sx={{ fontSize: { xs: '1.2rem', sm: '1.3rem', md: '1.5rem' } }} />
       </IconButton>
       <Menu
         anchorEl={anchorEl}
@@ -46,10 +47,12 @@ export function SettingsMenu() {
             borderColor: 'primary.main',
             boxShadow: '0 0 20px rgba(46, 127, 255, 0.3)',
             fontFamily: 'monospace',
+            minWidth: { xs: '200px', sm: '240px', md: '280px' },
+            maxWidth: { xs: '90vw', sm: '400px' },
           },
         }}
       >
-        <Box sx={{ px: 2, py: 1 }}>
+        <Box sx={{ px: { xs: 1.5, sm: 2 }, py: { xs: 1, sm: 1.5 } }}>
           <FormControlLabel
             control={
               <Switch
@@ -70,7 +73,7 @@ export function SettingsMenu() {
               color: 'text.primary',
               fontFamily: 'monospace',
               '& .MuiFormControlLabel-label': {
-                fontSize: '0.9rem',
+                fontSize: { xs: '0.8rem', sm: '0.85rem', md: '0.9rem' },
               },
             }}
           />
@@ -78,8 +81,8 @@ export function SettingsMenu() {
 
         <MuiDivider sx={{ borderColor: 'primary.main', opacity: 0.3, my: 1 }} />
 
-        <Box sx={{ px: 2, py: 1 }}>
-          <Box sx={{ color: 'text.secondary', fontSize: '0.75rem', mb: 1, textTransform: 'uppercase' }}>
+        <Box sx={{ px: { xs: 1.5, sm: 2 }, py: { xs: 1, sm: 1.5 } }}>
+          <Box sx={{ color: 'text.secondary', fontSize: { xs: '0.65rem', sm: '0.7rem', md: '0.75rem' }, mb: 1, textTransform: 'uppercase' }}>
             Color Theme
           </Box>
           {(Object.keys(COLOR_THEMES) as ColorTheme[]).map((themeKey) => (
@@ -89,8 +92,10 @@ export function SettingsMenu() {
               selected={settings.colorTheme === themeKey}
               sx={{
                 fontFamily: 'monospace',
-                fontSize: '0.85rem',
+                fontSize: { xs: '0.75rem', sm: '0.8rem', md: '0.85rem' },
                 color: 'text.primary',
+                minHeight: { xs: '44px', sm: '40px' },
+                px: { xs: 1, sm: 1.5 },
                 '&.Mui-selected': {
                   backgroundColor: 'rgba(46, 127, 255, 0.2)',
                   '&:hover': {

--- a/src/components/layout/AppBar.tsx
+++ b/src/components/layout/AppBar.tsx
@@ -11,7 +11,7 @@ export function AppBar() {
 
   return (
     <MuiAppBar position="static">
-      <Toolbar sx={{ py: 1 }}>
+      <Toolbar sx={{ py: { xs: 0.5, sm: 0.75, md: 1 } }}>
         <Box sx={{ flexGrow: 1 }}>
           <Typography
             variant="h6"
@@ -23,6 +23,7 @@ export function AppBar() {
               fontWeight: 700,
               letterSpacing: '0.15em',
               display: 'block',
+              fontSize: { xs: '0.9rem', sm: '1rem', md: '1.25rem' },
             }}
           >
             {APP_NAME.toUpperCase()}
@@ -32,22 +33,24 @@ export function AppBar() {
             sx={{
               color: 'text.secondary',
               letterSpacing: '0.1em',
-              fontSize: '0.7rem',
+              fontSize: { xs: '0.5rem', sm: '0.6rem', md: '0.7rem' },
+              display: { xs: 'none', sm: 'block' },
             }}
           >
             198X ARMY ROSTER SYSTEM v1.0
           </Typography>
         </Box>
 
-        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+        <Box sx={{ display: 'flex', gap: { xs: 0.5, sm: 0.75, md: 1 }, alignItems: 'center' }}>
           <Button
             color="inherit"
             component={RouterLink}
             to="/"
             sx={{
               color: 'primary.main',
-              fontSize: '0.85rem',
-              px: 2,
+              fontSize: { xs: '0.65rem', sm: '0.75rem', md: '0.85rem' },
+              px: { xs: 0.5, sm: 1, md: 2 },
+              minWidth: { xs: 'auto', sm: '64px' },
               '&:hover': {
                 backgroundColor: (theme) => `${theme.palette.primary.main}1A`,
               },
@@ -61,8 +64,9 @@ export function AppBar() {
             to="/builder"
             sx={{
               color: 'primary.main',
-              fontSize: '0.85rem',
-              px: 2,
+              fontSize: { xs: '0.65rem', sm: '0.75rem', md: '0.85rem' },
+              px: { xs: 0.5, sm: 1, md: 2 },
+              minWidth: { xs: 'auto', sm: '64px' },
               '&:hover': {
                 backgroundColor: (theme) => `${theme.palette.primary.main}1A`,
               },
@@ -76,8 +80,9 @@ export function AppBar() {
             to="/factions"
             sx={{
               color: 'primary.main',
-              fontSize: '0.85rem',
-              px: 2,
+              fontSize: { xs: '0.65rem', sm: '0.75rem', md: '0.85rem' },
+              px: { xs: 0.5, sm: 1, md: 2 },
+              minWidth: { xs: 'auto', sm: '64px' },
               '&:hover': {
                 backgroundColor: (theme) => `${theme.palette.primary.main}1A`,
               },
@@ -88,17 +93,23 @@ export function AppBar() {
           <Button
             color="inherit"
             onClick={() => setFeedbackOpen(true)}
-            startIcon={<FeedbackIcon sx={{ fontSize: '1rem' }} />}
+            startIcon={<FeedbackIcon sx={{ fontSize: { xs: '0.8rem', sm: '0.9rem', md: '1rem' } }} />}
             sx={{
               color: 'primary.main',
-              fontSize: '0.85rem',
-              px: 2,
+              fontSize: { xs: '0.65rem', sm: '0.75rem', md: '0.85rem' },
+              px: { xs: 0.5, sm: 1, md: 2 },
+              minWidth: { xs: 'auto', sm: '64px' },
               '&:hover': {
                 backgroundColor: (theme) => `${theme.palette.primary.main}1A`,
               },
             }}
           >
-            [FEEDBACK]
+            <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>
+              [FEEDBACK]
+            </Box>
+            <Box component="span" sx={{ display: { xs: 'inline', sm: 'none' } }}>
+              [FB]
+            </Box>
           </Button>
           <SettingsMenu />
         </Box>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -15,7 +15,8 @@ export function Layout({ children }: LayoutProps) {
         maxWidth="xl"
         sx={{
           flexGrow: 1,
-          py: 4,
+          py: { xs: 1.5, sm: 2.5, md: 4 },
+          px: { xs: 1, sm: 2, md: 3 },
         }}
       >
         {children}
@@ -23,8 +24,8 @@ export function Layout({ children }: LayoutProps) {
       <Box
         component="footer"
         sx={{
-          py: 2,
-          px: 2,
+          py: { xs: 1.5, sm: 2 },
+          px: { xs: 1.5, sm: 2 },
           mt: 'auto',
           borderTop: '1px solid #333',
           textAlign: 'center',
@@ -35,7 +36,7 @@ export function Layout({ children }: LayoutProps) {
           sx={{
             color: 'text.secondary',
             letterSpacing: '0.1em',
-            fontSize: '0.7rem',
+            fontSize: { xs: '0.55rem', sm: '0.65rem', md: '0.7rem' },
           }}
         >
           [UNAUTHORIZED ACCESS PROHIBITED] - RYGONET -{' '}


### PR DESCRIPTION
- Made AppBar buttons and spacing responsive with mobile-first breakpoints
- Added abbreviated "[FB]" text for Feedback button on mobile
- Hidden app subtitle on very small screens to save space
- Made SettingsMenu touch-friendly with larger tap targets (44px min)
- Optimized FeedbackDialog form inputs for mobile with appropriate font sizes
- Reduced excessive padding in Layout container on mobile devices
- Added responsive font sizes throughout to improve readability on all screen sizes

This addresses user feedback about laggy/flickering feedback entry and broken spacing when settings panel opens on mobile.